### PR TITLE
Update benchmark to be on par with Node.js

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -18,7 +18,7 @@ let connection_handler ({ request; _ } : Request_info.t Server.ctx) =
       Response.of_string ~headers `Not_found ~body:""
 
 let run ~sw ~host ~port ~domains env handler =
-  let config = Server.Config.create ~domains (`Tcp (host, port)) in
+  let config = Server.Config.create ~domains ~buffer_size:0x1000 (`Tcp (host, port)) in
   let server = Server.create ~config handler in
   let command = Server.Command.start ~sw env server in
   command


### PR DESCRIPTION
Turns out, as usual, your benchmarks tend to depend on how much you allocate. So using a smaller buffer size for every outgoing response makes the benchmark perform a lot better.

I still need to fix this in Piaf, though. Buffer sizes should be bigger for reading (and allocated less often) and smaller for writing. I think that'll make a better default.